### PR TITLE
feat(ui): Toggle when clicking on description text

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.9/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
 	"files": {
 		"includes": [

--- a/src/renderer/components/Preference/CloudSinks.vue
+++ b/src/renderer/components/Preference/CloudSinks.vue
@@ -1932,7 +1932,7 @@ export default defineComponent({
 	align-items: flex-start;
 }
 
-.dialog-field-toggle .ui-checkbox__label {
+.dialog-field-toggle :deep(.ui-checkbox__label) {
 	display: flex;
 	flex-direction: column;
 	min-width: 0;

--- a/src/renderer/components/Preference/CloudSinks.vue
+++ b/src/renderer/components/Preference/CloudSinks.vue
@@ -296,11 +296,10 @@
               </div>
             </div>
             <div class="dialog-field-toggle">
-              <ui-checkbox v-model="form.webdav.insecure" />
-              <div>
+              <ui-checkbox v-model="form.webdav.insecure">
                 <span class="toggle-title">{{ $t('cloudSinks.allowInsecure') }}</span>
                 <span class="toggle-hint">{{ $t('cloudSinks.allowInsecureHint') }}</span>
-              </div>
+              </ui-checkbox>
             </div>
           </template>
 
@@ -347,11 +346,10 @@
               <p class="dialog-hint">{{ $t('cloudSinks.s3PrefixHint') }}</p>
             </div>
             <div class="dialog-field-toggle">
-              <ui-checkbox v-model="form.s3.forcePathStyle" />
-              <div>
+              <ui-checkbox v-model="form.s3.forcePathStyle">
                 <span class="toggle-title">{{ $t('cloudSinks.s3PathStyle') }}</span>
                 <span class="toggle-hint">{{ $t('cloudSinks.s3PathStyleHint') }}</span>
-              </div>
+              </ui-checkbox>
             </div>
           </template>
 
@@ -444,18 +442,16 @@
               <Input v-model="form.ftp.basePath" placeholder="/uploads" autocomplete="off" />
             </div>
             <div class="dialog-field-toggle">
-              <ui-checkbox v-model="form.ftp.secure" />
-              <div>
+              <ui-checkbox v-model="form.ftp.secure">
                 <span class="toggle-title">{{ $t('cloudSinks.ftpSecure') }}</span>
                 <span class="toggle-hint">{{ $t('cloudSinks.ftpSecureHint') }}</span>
-              </div>
+              </ui-checkbox>
             </div>
             <div v-if="form.ftp.secure" class="dialog-field-toggle">
-              <ui-checkbox v-model="form.ftp.insecure" />
-              <div>
+              <ui-checkbox v-model="form.ftp.insecure">
                 <span class="toggle-title">{{ $t('cloudSinks.allowInsecure') }}</span>
                 <span class="toggle-hint">{{ $t('cloudSinks.allowInsecureHint') }}</span>
-              </div>
+              </ui-checkbox>
             </div>
           </template>
 
@@ -714,11 +710,10 @@
           <hr class="dialog-sep" />
 
           <div class="dialog-field-toggle">
-            <ui-checkbox v-model="ruleForm.enabled" />
-            <div>
+            <ui-checkbox v-model="ruleForm.enabled">
               <span class="toggle-title">{{ $t('cloudSinks.ruleEnabled') }}</span>
               <span class="toggle-hint">{{ $t('cloudSinks.ruleEnabledHint') }}</span>
-            </div>
+            </ui-checkbox>
           </div>
 
           <div v-if="ruleDialogError" class="dialog-error">
@@ -1932,7 +1927,12 @@ export default defineComponent({
 	background: hsl(var(--muted) / 0.3);
 }
 
-.dialog-field-toggle > div {
+.dialog-field-toggle .ui-checkbox {
+	width: 100%;
+	align-items: flex-start;
+}
+
+.dialog-field-toggle .ui-checkbox__label {
 	display: flex;
 	flex-direction: column;
 	min-width: 0;

--- a/src/renderer/components/Preference/Usenet.vue
+++ b/src/renderer/components/Preference/Usenet.vue
@@ -422,8 +422,9 @@
               <strong>{{ $t('preferences.usenet-plain-warning-title') }}</strong>
               <p>{{ $t('preferences.usenet-plain-warning') }}</p>
 								<div class="plain-confirmation">
-									<ui-checkbox v-model="profileForm.allowPlain" />
-									<span>{{ $t('preferences.usenet-plain-opt-in') }}</span>
+									<ui-checkbox v-model="profileForm.allowPlain">
+										{{ $t('preferences.usenet-plain-opt-in') }}
+									</ui-checkbox>
 								</div>
             </div>
           </div>
@@ -1459,6 +1460,10 @@ export default defineComponent({
 	color: var(--text-1);
 	font-size: 12px;
 	cursor: pointer;
+}
+
+.plain-confirmation .ui-checkbox {
+	width: 100%;
 }
 
 .dialog-error {

--- a/src/renderer/components/Task/SelectTorrent.vue
+++ b/src/renderer/components/Task/SelectTorrent.vue
@@ -100,10 +100,13 @@
                 }}
               </button>
               <template v-else>
-                <span
+                <button
+                  type="button"
                   class="torrent-preview-name-text"
+                  :disabled="isPreviewNameDisabled(row)"
+                  :aria-pressed="previewNameAriaPressed(row)"
                   @click="onPreviewNameClick(row)"
-                >{{ row.name }}</span>
+                >{{ row.name }}</button>
                 <span v-if="row.loading" class="torrent-preview-loading-tag">
                   {{ $t('task.torrent-preview-folder-loading') }}
                 </span>
@@ -784,13 +787,32 @@ export default {
 						]);
 			this.emitPreviewSelectionChange();
 		},
+		isPreviewNameDisabled(row: PreviewTreeRow): boolean {
+			return (
+				row.type === "folder" &&
+				(row.loading || !this.hasPreviewFolderSelectableRange(row))
+			);
+		},
+		previewNameAriaPressed(row: PreviewTreeRow): boolean | "mixed" {
+			if (row.type === "file") {
+				return this.isPreviewFileSelected(row);
+			}
+			if (row.type === "folder") {
+				const state = this.previewFolderSelectionState(row);
+				if (state === "indeterminate") {
+					return "mixed";
+				}
+				return state === true;
+			}
+			return false;
+		},
 		onPreviewNameClick(row: PreviewTreeRow) {
 			if (row.type === "file") {
 				this.togglePreviewFileSelection(row, !this.isPreviewFileSelected(row));
 				return;
 			}
 			if (row.type === "folder") {
-				if (row.loading || !this.hasPreviewFolderSelectableRange(row)) {
+				if (this.isPreviewNameDisabled(row)) {
 					return;
 				}
 				this.togglePreviewFolderSelection(

--- a/src/renderer/components/Task/SelectTorrent.vue
+++ b/src/renderer/components/Task/SelectTorrent.vue
@@ -100,7 +100,10 @@
                 }}
               </button>
               <template v-else>
-                <span class="torrent-preview-name-text">{{ row.name }}</span>
+                <span
+                  class="torrent-preview-name-text"
+                  @click="onPreviewNameClick(row)"
+                >{{ row.name }}</span>
                 <span v-if="row.loading" class="torrent-preview-loading-tag">
                   {{ $t('task.torrent-preview-folder-loading') }}
                 </span>
@@ -780,6 +783,21 @@ export default {
 							...normalizedRanges,
 						]);
 			this.emitPreviewSelectionChange();
+		},
+		onPreviewNameClick(row: PreviewTreeRow) {
+			if (row.type === "file") {
+				this.togglePreviewFileSelection(row, !this.isPreviewFileSelected(row));
+				return;
+			}
+			if (row.type === "folder") {
+				if (row.loading || !this.hasPreviewFolderSelectableRange(row)) {
+					return;
+				}
+				this.togglePreviewFolderSelection(
+					row,
+					this.previewFolderSelectionState(row) !== true,
+				);
+			}
 		},
 		togglePreviewFolderSelection(
 			row: PreviewTreeRow,

--- a/src/renderer/components/TaskDetail/TaskFiles.vue
+++ b/src/renderer/components/TaskDetail/TaskFiles.vue
@@ -29,12 +29,13 @@
                 @update:model-value="(val) => toggleRow(item, val)"
               />
             </span>
-            <span
+            <button
+              type="button"
               class="task-files-name"
               :title="item.path || item.name"
+              :aria-pressed="isSelected(item)"
               @click="toggleRow(item, !isSelected(item))"
-              @dblclick.stop
-            >{{ item.name }}</span>
+            >{{ item.name }}</button>
             <span>{{ formatExtension(item.extension) }}</span>
             <span class="task-files-num">{{ calcProgress(item.length, item.completedLength, 1) }}</span>
             <span class="task-files-num">{{ formatBytes(item.completedLength) }}</span>
@@ -75,13 +76,16 @@
                 @update:model-value="(val) => toggleRow(row, val)"
               />
             </TableCell>
-            <TableCell
-              class="truncate max-w-50 cursor-pointer"
-              :title="row.path || row.name"
-              @click="toggleRow(row, !isSelected(row))"
-              @dblclick.stop
-            >
-              {{ row.name }}
+            <TableCell class="max-w-50">
+              <button
+                type="button"
+                class="task-files-name"
+                :title="row.path || row.name"
+                :aria-pressed="isSelected(row)"
+                @click="toggleRow(row, !isSelected(row))"
+              >
+                {{ row.name }}
+              </button>
             </TableCell>
             <TableCell>{{ formatExtension(row.extension) }}</TableCell>
             <TableCell class="text-right">{{ formatBytes(row.length) }}</TableCell>

--- a/src/renderer/components/TaskDetail/TaskFiles.vue
+++ b/src/renderer/components/TaskDetail/TaskFiles.vue
@@ -34,7 +34,8 @@
               class="task-files-name"
               :title="item.path || item.name"
               :aria-pressed="isSelected(item)"
-              @click="toggleRow(item, !isSelected(item))"
+              @click="onNameClick(item, $event)"
+              @dblclick.stop
             >{{ item.name }}</button>
             <span>{{ formatExtension(item.extension) }}</span>
             <span class="task-files-num">{{ calcProgress(item.length, item.completedLength, 1) }}</span>
@@ -82,7 +83,8 @@
                 class="task-files-name"
                 :title="row.path || row.name"
                 :aria-pressed="isSelected(row)"
-                @click="toggleRow(row, !isSelected(row))"
+                @click="onNameClick(row, $event)"
+                @dblclick.stop
               >
                 {{ row.name }}
               </button>
@@ -268,6 +270,12 @@ export default {
 				next.delete(row.idx);
 			}
 			this.selectedIndices = next;
+		},
+		onNameClick(row: TaskFileRow, event: MouseEvent) {
+			if (event.detail > 1) {
+				return;
+			}
+			this.toggleRow(row, !this.isSelected(row));
 		},
 		toggleAllSelection() {
 			this.selectedIndices = new Set(

--- a/src/renderer/components/TaskDetail/TaskFiles.vue
+++ b/src/renderer/components/TaskDetail/TaskFiles.vue
@@ -29,7 +29,12 @@
                 @update:model-value="(val) => toggleRow(item, val)"
               />
             </span>
-            <span class="task-files-name" :title="item.path || item.name">{{ item.name }}</span>
+            <span
+              class="task-files-name"
+              :title="item.path || item.name"
+              @click="toggleRow(item, !isSelected(item))"
+              @dblclick.stop
+            >{{ item.name }}</span>
             <span>{{ formatExtension(item.extension) }}</span>
             <span class="task-files-num">{{ calcProgress(item.length, item.completedLength, 1) }}</span>
             <span class="task-files-num">{{ formatBytes(item.completedLength) }}</span>
@@ -70,7 +75,12 @@
                 @update:model-value="(val) => toggleRow(row, val)"
               />
             </TableCell>
-            <TableCell class="truncate max-w-50" :title="row.path || row.name">
+            <TableCell
+              class="truncate max-w-50 cursor-pointer"
+              :title="row.path || row.name"
+              @click="toggleRow(row, !isSelected(row))"
+              @dblclick.stop
+            >
               {{ row.name }}
             </TableCell>
             <TableCell>{{ formatExtension(row.extension) }}</TableCell>

--- a/src/renderer/components/ui/compat/UiCheckbox.vue
+++ b/src/renderer/components/ui/compat/UiCheckbox.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useAttrs } from "vue";
+import { computed, useAttrs, type HTMLAttributes } from "vue";
 import { Checkbox } from "../checkbox";
 
 defineOptions({ inheritAttrs: false });
@@ -10,6 +10,7 @@ const props = withDefaults(
 	defineProps<{
 		modelValue?: boolean;
 		disabled?: boolean;
+		class?: HTMLAttributes["class"];
 	}>(),
 	{
 		modelValue: false,
@@ -29,10 +30,27 @@ const checked = computed({
 		emit("change", val);
 	},
 });
+
+function onLabelClick(event: MouseEvent) {
+	const target = event.target;
+	if (target instanceof Element && target.closest("[data-slot='checkbox']")) {
+		return;
+	}
+	// Reka-ui renders a button, so a native <label> click would toggle twice.
+	event.preventDefault();
+	if (props.disabled) {
+		return;
+	}
+	checked.value = !checked.value;
+}
 </script>
 
 <template>
-  <label class="ui-checkbox" :class="{ 'is-disabled': disabled }">
+  <label
+    class="ui-checkbox"
+    :class="[props.class, { 'is-disabled': disabled }]"
+    @click="onLabelClick"
+  >
     <Checkbox
       v-bind="attrs"
       :model-value="checked"
@@ -43,7 +61,7 @@ const checked = computed({
         }
       "
     />
-    <span class="ui-checkbox__label">
+    <span v-if="$slots.default" class="ui-checkbox__label">
       <slot />
     </span>
   </label>

--- a/src/renderer/components/ui/confirm-dialog/ConfirmDialog.vue
+++ b/src/renderer/components/ui/confirm-dialog/ConfirmDialog.vue
@@ -2,7 +2,7 @@
 import { TriangleAlert } from "@lucide/vue";
 import { ref, watch } from "vue";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
+import UiCheckbox from "@/components/ui/compat/UiCheckbox.vue";
 import {
 	Dialog,
 	DialogContent,
@@ -10,7 +10,6 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 
 const props = withDefaults(
 	defineProps<{
@@ -98,18 +97,15 @@ function onOpenChange(val: boolean) {
         <p class="min-w-0 wrap-anywhere text-[13px] leading-relaxed text-muted-foreground">
           {{ message }}
         </p>
-        <label
+        <UiCheckbox
           v-if="checkboxLabel"
-          class="flex min-w-0 cursor-pointer select-none items-center gap-2 pt-1"
+          v-model="checked"
+          class="pt-1"
         >
-          <Checkbox
-            :model-value="checked"
-            @update:model-value="(val: boolean) => (checked = val)"
-          />
-          <Label class="min-w-0 cursor-pointer wrap-break-word text-[13px] font-normal">
+          <span class="min-w-0 wrap-break-word text-[13px] font-normal">
             {{ checkboxLabel }}
-          </Label>
-        </label>
+          </span>
+        </UiCheckbox>
       </div>
       <DialogFooter class="w-full flex-row flex-wrap justify-end gap-2 border-t px-5 py-3">
         <Button variant="outline" size="sm" @click="onCancel">

--- a/src/renderer/styles/components/compat.css
+++ b/src/renderer/styles/components/compat.css
@@ -29,6 +29,7 @@
 		cursor: pointer;
 		user-select: none;
 		line-height: 1.3;
+		position: relative;
 	}
 	.ui-checkbox__label {
 		color: inherit;
@@ -37,29 +38,33 @@
 		opacity: 0.55;
 		cursor: not-allowed;
 	}
-	.settings-row:has(> .settings-row-action .ui-checkbox),
-	.dialog-field-toggle,
-	.plain-confirmation {
+	.settings-row:has(> .settings-row-action .ui-checkbox) {
 		position: relative;
+		z-index: 0;
 		cursor: pointer;
-		user-select: none;
 	}
 	.settings-row:has(> .settings-row-action .ui-checkbox):has(
 		.ui-checkbox.is-disabled
-	),
-	.dialog-field-toggle:has(.ui-checkbox.is-disabled),
-	.plain-confirmation:has(.ui-checkbox.is-disabled) {
+	) {
 		cursor: not-allowed;
 	}
 	.settings-row:has(> .settings-row-action .ui-checkbox)
 		> .settings-row-action
-		.ui-checkbox::after,
-	.dialog-field-toggle .ui-checkbox::after,
-	.plain-confirmation .ui-checkbox::after {
+		.ui-checkbox {
+		position: static;
+	}
+	.settings-row:has(> .settings-row-action .ui-checkbox)
+		> .settings-row-action
+		.ui-checkbox::after {
 		content: "";
 		position: absolute;
 		inset: 0;
 		z-index: 1;
+	}
+	.settings-row:has(> .settings-row-action .ui-checkbox)
+		:is(a, button, input, textarea, select, [data-slot="checkbox"]) {
+		position: relative;
+		z-index: 2;
 	}
 	.ui-progress {
 		height: 6px;

--- a/src/renderer/styles/components/compat.css
+++ b/src/renderer/styles/components/compat.css
@@ -37,6 +37,30 @@
 		opacity: 0.55;
 		cursor: not-allowed;
 	}
+	.settings-row:has(> .settings-row-action .ui-checkbox),
+	.dialog-field-toggle,
+	.plain-confirmation {
+		position: relative;
+		cursor: pointer;
+		user-select: none;
+	}
+	.settings-row:has(> .settings-row-action .ui-checkbox):has(
+		.ui-checkbox.is-disabled
+	),
+	.dialog-field-toggle:has(.ui-checkbox.is-disabled),
+	.plain-confirmation:has(.ui-checkbox.is-disabled) {
+		cursor: not-allowed;
+	}
+	.settings-row:has(> .settings-row-action .ui-checkbox)
+		> .settings-row-action
+		.ui-checkbox::after,
+	.dialog-field-toggle .ui-checkbox::after,
+	.plain-confirmation .ui-checkbox::after {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+	}
 	.ui-progress {
 		height: 6px;
 	}

--- a/src/renderer/styles/components/task-detail.css
+++ b/src/renderer/styles/components/task-detail.css
@@ -460,11 +460,27 @@
 		background: var(--primary-soft);
 	}
 	.task-files-name {
+		display: block;
+		box-sizing: border-box;
+		width: 100%;
+		max-width: 100%;
 		min-width: 0;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: transparent;
+		font: inherit;
+		color: inherit;
+		text-align: start;
 		cursor: pointer;
+	}
+	.task-files-name:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: -2px;
+		border-radius: 4px;
 	}
 	.task-files-num {
 		text-align: right;

--- a/src/renderer/styles/components/task-detail.css
+++ b/src/renderer/styles/components/task-detail.css
@@ -464,6 +464,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+		cursor: pointer;
 	}
 	.task-files-num {
 		text-align: right;

--- a/src/renderer/styles/components/torrent.css
+++ b/src/renderer/styles/components/torrent.css
@@ -189,7 +189,22 @@
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: transparent;
+		font: inherit;
+		color: inherit;
+		text-align: start;
 		cursor: pointer;
+	}
+	.selective-torrent .torrent-preview-name-text:disabled {
+		cursor: default;
+	}
+	.selective-torrent .torrent-preview-name-text:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
+		border-radius: 4px;
 	}
 	.selective-torrent .torrent-preview-load-more-btn {
 		border: none;

--- a/src/renderer/styles/components/torrent.css
+++ b/src/renderer/styles/components/torrent.css
@@ -189,6 +189,7 @@
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
+		cursor: pointer;
 	}
 	.selective-torrent .torrent-preview-load-more-btn {
 		border: none;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes checkbox labels and file/folder names in task lists clickable to toggle their checkbox, so users no longer need to click the small box itself.

- Extends `UiCheckbox` to render a clickable label from slot content and ignores clicks that already hit the checkbox.
- Migrates CloudSinks, Usenet plain confirmation, and ConfirmDialog to the new label pattern.
- Turns file/folder name rows in TaskFiles and SelectTorrent into accessible toggle buttons with focus styles and pointer cursors.
- Bumps the biome schema from 2.5.9 to 2.5.10.

<sup>Written for commit f131ac1ba857f85abb7bff2baa0625c3b3ddcc24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

