### PR TITLE
feat: configure task connection count

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import cfonts from "cfonts";
 import chalk from "chalk";
 
@@ -46,8 +47,9 @@ function greeting() {
 greeting();
 
 const args = process.argv.slice(2);
-const tauriArgs = ["tauri", "build", ...args];
-const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const require = createRequire(import.meta.url);
+const tauriBin = require.resolve("@tauri-apps/cli/tauri.js");
+const tauriArgs = [tauriBin, "build", ...args];
 
 function findOptionValue(rawArgs, flags) {
 	for (const flag of flags) {
@@ -144,7 +146,7 @@ if (!userProvidedConfig && resourceConfig) {
 	);
 }
 
-const child = spawn(pnpmBin, tauriArgs, {
+const child = spawn(process.execPath, tauriArgs, {
 	stdio: "inherit",
 	shell: false,
 	env: { ...process.env },

--- a/src-tauri/risuko-engine/src/engine/archive_pipeline.rs
+++ b/src-tauri/risuko-engine/src/engine/archive_pipeline.rs
@@ -272,17 +272,18 @@ where
                     .map_err(ArchivePipelineError::Io)?;
                 file.sync_all().map_err(ArchivePipelineError::Io)?;
                 // Never preserve executable bits from archive metadata
-                let mut perms = file
-                    .metadata()
-                    .map_err(ArchivePipelineError::Io)?
-                    .permissions();
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;
+
+                    let mut perms = file
+                        .metadata()
+                        .map_err(ArchivePipelineError::Io)?
+                        .permissions();
                     perms.set_mode(perms.mode() & 0o666);
+                    file.set_permissions(perms)
+                        .map_err(ArchivePipelineError::Io)?;
                 }
-                file.set_permissions(perms)
-                    .map_err(ArchivePipelineError::Io)?;
                 files_written += 1;
             }
             _ => unreachable!(),

--- a/src-tauri/src/managers/clip_prompt.rs
+++ b/src-tauri/src/managers/clip_prompt.rs
@@ -17,7 +17,7 @@ pub fn setup_clip_prompt(app: &tauri::App) -> Result<(), Box<dyn std::error::Err
         return Ok(());
     }
 
-    let mut builder = WebviewWindowBuilder::new(
+    let builder = WebviewWindowBuilder::new(
         app,
         CLIP_PROMPT_LABEL,
         WebviewUrl::App("clip-prompt.html".into()),
@@ -35,9 +35,7 @@ pub fn setup_clip_prompt(app: &tauri::App) -> Result<(), Box<dyn std::error::Err
     .accept_first_mouse(true);
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder.visible_on_all_workspaces(true);
-    }
+    let builder = builder.visible_on_all_workspaces(true);
 
     builder.build()?;
     Ok(())

--- a/src-tauri/src/managers/flyout.rs
+++ b/src-tauri/src/managers/flyout.rs
@@ -23,24 +23,21 @@ pub fn setup_flyout(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> 
         return Ok(());
     }
 
-    let mut builder =
-        WebviewWindowBuilder::new(app, FLYOUT_LABEL, WebviewUrl::App("tray.html".into()))
-            .title("Risuko Quick Panel")
-            .inner_size(FLYOUT_WIDTH, FLYOUT_HEIGHT)
-            .decorations(false)
-            .always_on_top(true)
-            .skip_taskbar(true)
-            .resizable(false)
-            .visible(false)
-            .focused(false)
-            .transparent(true)
-            .shadow(false)
-            .accept_first_mouse(true);
+    let builder = WebviewWindowBuilder::new(app, FLYOUT_LABEL, WebviewUrl::App("tray.html".into()))
+        .title("Risuko Quick Panel")
+        .inner_size(FLYOUT_WIDTH, FLYOUT_HEIGHT)
+        .decorations(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .resizable(false)
+        .visible(false)
+        .focused(false)
+        .transparent(true)
+        .shadow(false)
+        .accept_first_mouse(true);
 
     #[cfg(target_os = "macos")]
-    {
-        builder = builder.visible_on_all_workspaces(true);
-    }
+    let builder = builder.visible_on_all_workspaces(true);
 
     builder.build()?;
     Ok(())

--- a/src-tauri/src/utils/run_mode.rs
+++ b/src-tauri/src/utils/run_mode.rs
@@ -1,9 +1,9 @@
 use tauri::{AppHandle, Manager};
 
 pub const RUN_MODE_STANDARD: i64 = 1;
-#[cfg(not(target_os = "android"))]
+#[cfg(target_os = "macos")]
 pub const RUN_MODE_TRAY: i64 = 2;
-#[cfg(not(target_os = "android"))]
+#[cfg(target_os = "macos")]
 pub const RUN_MODE_HIDE_TRAY_LEGACY: i64 = 3;
 
 /// Get the current run mode from app config (1 = standard, 2 = tray, 3 = hide tray legacy)
@@ -22,7 +22,7 @@ pub fn current_run_mode(handle: &AppHandle) -> i64 {
 }
 
 /// Check if the current run mode is a tray mode (2 or 3)
-#[cfg(not(target_os = "android"))]
+#[cfg(target_os = "macos")]
 pub fn is_tray_mode(run_mode: i64) -> bool {
     matches!(run_mode, RUN_MODE_TRAY | RUN_MODE_HIDE_TRAY_LEGACY)
 }

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -380,7 +380,10 @@
           </div>
           <div class="settings-section-content">
             <div class="settings-select-group">
-              <div class="settings-select-item">
+              <div
+                class="settings-select-item"
+                data-preference-search-target="preferences.max-concurrent-downloads"
+              >
                 <label class="settings-select-item-label">{{
                   $t('preferences.max-concurrent-downloads')
                 }}</label>
@@ -389,6 +392,15 @@
                   :min="1"
                   :max="maxConcurrentDownloads"
                 />
+              </div>
+              <div
+                class="settings-select-item"
+                data-preference-search-target="preferences.connections-per-task"
+              >
+                <label class="settings-select-item-label">{{
+                  $t('preferences.connections-per-task')
+                }}</label>
+                <NumberInput v-model="form.split" :min="1" :max="128" />
               </div>
             </div>
             <div
@@ -759,6 +771,10 @@ const normalizeBasicConfig = (data) => {
 		);
 	}
 
+	if ("split" in data) {
+		data.split = normalizePositiveInt(data.split, 16, 1, 128);
+	}
+
 	if ("lowSpeedThreshold" in data) {
 		data.lowSpeedThreshold = normalizePositiveInt(
 			data.lowSpeedThreshold,
@@ -818,6 +834,7 @@ const initForm = (config) => {
 		seedRatio,
 		seedTime,
 		taskNotification,
+		split,
 		useRemoteFileTime,
 		lowSpeedThreshold,
 	} = config;
@@ -858,7 +875,7 @@ const initForm = (config) => {
 		keepWindowState: parseBooleanConfig(keepWindowState),
 		locale,
 		lowSpeedThreshold: normalizePositiveInt(lowSpeedThreshold, 20, 1, 10240),
-		maxConcurrentDownloads,
+		split: normalizePositiveInt(split, 16, 1, 128),
 		maxOverallDownloadLimit,
 		maxOverallUploadLimit,
 		newTaskShowDownloading: parseBooleanConfig(newTaskShowDownloading),

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -775,6 +775,15 @@ const normalizeBasicConfig = (data) => {
 		data.split = normalizePositiveInt(data.split, 16, 1, 128);
 	}
 
+	if ("maxConcurrentDownloads" in data) {
+		data.maxConcurrentDownloads = normalizePositiveInt(
+			data.maxConcurrentDownloads,
+			5,
+			1,
+			ENGINE_MAX_CONCURRENT_DOWNLOADS,
+		);
+	}
+
 	if ("lowSpeedThreshold" in data) {
 		data.lowSpeedThreshold = normalizePositiveInt(
 			data.lowSpeedThreshold,
@@ -875,7 +884,12 @@ const initForm = (config) => {
 		keepWindowState: parseBooleanConfig(keepWindowState),
 		locale,
 		lowSpeedThreshold: normalizePositiveInt(lowSpeedThreshold, 20, 1, 10240),
-		maxConcurrentDownloads,
+		maxConcurrentDownloads: normalizePositiveInt(
+			maxConcurrentDownloads,
+			5,
+			1,
+			ENGINE_MAX_CONCURRENT_DOWNLOADS,
+		),
 		split: normalizePositiveInt(split, 16, 1, 128),
 		maxOverallDownloadLimit,
 		maxOverallUploadLimit,

--- a/src/renderer/components/Preference/Basic.vue
+++ b/src/renderer/components/Preference/Basic.vue
@@ -875,6 +875,7 @@ const initForm = (config) => {
 		keepWindowState: parseBooleanConfig(keepWindowState),
 		locale,
 		lowSpeedThreshold: normalizePositiveInt(lowSpeedThreshold, 20, 1, 10240),
+		maxConcurrentDownloads,
 		split: normalizePositiveInt(split, 16, 1, 128),
 		maxOverallDownloadLimit,
 		maxOverallUploadLimit,

--- a/src/renderer/components/Preference/search.ts
+++ b/src/renderer/components/Preference/search.ts
@@ -278,6 +278,7 @@ const BASIC_KEYS = [
 	"preferences.seed-ratio",
 	"preferences.seed-time",
 	"preferences.max-concurrent-downloads",
+	"preferences.connections-per-task",
 	"preferences.auto-retry",
 	"preferences.auto-retry-strategy",
 	"preferences.auto-retry-strategy-exponential",

--- a/src/shared/locales/en-US/preferences.ts
+++ b/src/shared/locales/en-US/preferences.ts
@@ -169,6 +169,7 @@ export default {
 	"seed-time-unit": "minutes",
 	"task-manage": "Task Management",
 	"max-concurrent-downloads": "Maximum active tasks",
+	"connections-per-task": "Connections per task",
 	"max-connection-per-server": "Maximum connections per server",
 	"auto-retry": "Auto-retry failed tasks",
 	"auto-retry-strategy": "Retry interval mode",

--- a/src/shared/locales/zh-CN/preferences.ts
+++ b/src/shared/locales/zh-CN/preferences.ts
@@ -47,6 +47,7 @@ export default {
 	"seed-time-unit": "分钟",
 	"task-manage": "任务管理",
 	"max-concurrent-downloads": "同时下载的最大任务数",
+	"connections-per-task": "单任务连接数",
 	"max-connection-per-server": "每个服务器最大连接数",
 	"auto-retry": "失败任务自动重试",
 	"auto-retry-strategy": "重试间隔模式",

--- a/src/shared/locales/zh-TW/preferences.ts
+++ b/src/shared/locales/zh-TW/preferences.ts
@@ -37,6 +37,7 @@ export default {
 	"seed-time-unit": "分鐘",
 	"task-manage": "任務管理",
 	"max-concurrent-downloads": "最多可同時下載的任務數",
+	"connections-per-task": "單一任務連線數",
 	"max-connection-per-server": "每台伺服器的最大連線數",
 	"auto-retry": "失敗任務自動重試",
 	"auto-retry-strategy": "重試間隔模式",


### PR DESCRIPTION
## Description

支持配置并持久化单任务中的连接数量

### Checklist:

- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you linted your code locally prior to submission?
- [x] Have you successfully ran app with your changes locally?

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable per-task connection count via a new "Connections per task" preference (1–128, default 16) that is persisted and normalized in the config form. Also normalizes and makes searchable the "Maximum active tasks" setting, restricts tray run-mode support to macOS, and drops the pnpm dependency from the build script.

**New Features**
- New "Connections per task" setting with search support and en-US, zh-CN, zh-TW translations.

**Refactors**
- Build script resolves `@tauri-apps/cli/tauri.js` and runs it with the current Node executable instead of spawning pnpm.
- Tray-mode constants and `is_tray_mode` are now compiled only on macOS instead of all non-Android platforms.
- Window builders in `clip_prompt.rs` and `flyout.rs` use `let` shadowing instead of `mut`.
- Archive extraction now sets file permissions only on Unix, dropping a no-op call on other platforms.

<sup>Written for commit 10abb4998f189eb307d5013fe674a29feac5756a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YueMiyuki/Risuko/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

